### PR TITLE
fix(leave): validate leave startDateTime must be before endDateTime (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 ### env varivale ###
 *.env
+.env.dev

--- a/src/main/java/com/tsmc/cloudnative/attendancesystemapi/service/LeaveApplicationService.java
+++ b/src/main/java/com/tsmc/cloudnative/attendancesystemapi/service/LeaveApplicationService.java
@@ -165,6 +165,11 @@ public class LeaveApplicationService {
             )
             .orElseThrow(() -> new IllegalArgumentException("查無該假別的請假餘額"));
 
+        // 驗證開始時間需早於結束時間
+        if (!requestDTO.getStartDateTime().isBefore(requestDTO.getEndDatetime())) {
+            throw new IllegalArgumentException("開始時間需早於結束時間");
+        }
+
         // 驗證請假時數是否超過餘額
         if (requestDTO.getLeaveHours() > balance.getRemainingHours()) {
             throw new IllegalArgumentException("請假時數超過可用餘額");


### PR DESCRIPTION
fix(leave): validate leave startDateTime must be before endDateTime (#8)

- Added validation logic to ensure leave startDateTime is strictly before endDateTime
- Throws IllegalArgumentException if invalid range is detected
- Related to issue #8
- Closes #8